### PR TITLE
Prepare tests for bad JSON input

### DIFF
--- a/chat_message_test.go
+++ b/chat_message_test.go
@@ -31,14 +31,19 @@ func TestNewChatMessage(t *testing.T) {
 	}
 }
 
-// TestAssignID ensures that the AssignID function actually populates the UUID field
-// of the ChatMessage
-func TestAssignID(t *testing.T) {
+func newMessageOrSkip(t *testing.T, content string) *arbor.ChatMessage {
 	m, err := arbor.NewChatMessage(testContent)
 	if err != nil || m == nil {
 		t.Skip("Unable to create message")
 	}
-	err = m.AssignID()
+	return m
+}
+
+// TestAssignID ensures that the AssignID function actually populates the UUID field
+// of the ChatMessage
+func TestAssignID(t *testing.T) {
+	m := newMessageOrSkip(t, testContent)
+	err := m.AssignID()
 	if err != nil {
 		t.Error("Failed to assign UUID", err)
 		return
@@ -55,11 +60,8 @@ func unreasonableTimestamp(timestamp int64) bool {
 // TestReply ensures that the Reply method creates a new ChatMessage with the correct
 // Parent and Content as well as a reasonable Timestamp.
 func TestReply(t *testing.T) {
-	m, err := arbor.NewChatMessage(testContent)
-	if err != nil || m == nil {
-		t.Skip("Unable to create message")
-	}
-	err = m.AssignID()
+	m := newMessageOrSkip(t, testContent)
+	err := m.AssignID()
 	if err != nil || m.UUID == "" {
 		t.Skip("Failed to assign UUID", err)
 		return

--- a/io.go
+++ b/io.go
@@ -32,7 +32,8 @@ func MakeMessageWriter(conn io.Writer) chan<- *ProtocolMessage {
 // MakeMessageReader wraps the io.Reader and returns a channel of
 // ProtocolMessage pointers. Any JSON received over the io.Reader will
 // be unmarshalled into an ProtocolMessage struct and sent over the returned
-// channel.
+// channel. If invalid JSON is received, the Reader will discard bytes
+// until EOF or it finds valid JSON again.
 func MakeMessageReader(conn io.Reader) <-chan *ProtocolMessage {
 	output := make(chan *ProtocolMessage)
 	go func() {

--- a/io.go
+++ b/io.go
@@ -48,7 +48,12 @@ func MakeMessageReader(conn io.ReadCloser) <-chan *ProtocolMessage {
 					return
 				}
 				// if we received unparsable JSON, just hang up.
-				defer conn.Close()
+				defer func() {
+					if closeErr := conn.Close(); closeErr != nil {
+						log.Println("Error closing connection:", closeErr)
+					}
+				}()
+
 				log.Println("Error decoding json, hanging up:", err)
 				return
 			}

--- a/io_test.go
+++ b/io_test.go
@@ -1,0 +1,30 @@
+package arbor_test
+
+import (
+	"testing"
+
+	arbor "github.com/arborchat/arbor-go"
+	"github.com/jordwest/mock-conn"
+)
+
+// TestMakeMessageReader checks that MakeMessageReader properly reads messages
+// from the input io.Reader.
+func TestMakeMessageReader(t *testing.T) {
+	testMsgs := []string{
+		"{}\n",
+	}
+	conn := mock_conn.NewConn()
+	recvChan := arbor.MakeMessageReader(conn.Client)
+	server := conn.Server
+	for _, msg := range testMsgs {
+		testMsg := []byte(msg)
+		n, err := server.Write(testMsg)
+		if err != nil || n != len(testMsg) {
+			t.Skipf("Unable to write message \"%s\" into mock connection", msg)
+		}
+		parsed := <-recvChan
+		if parsed == nil {
+			t.Error("MakeMessageReader sent nil ProtocolMessage")
+		}
+	}
+}

--- a/io_test.go
+++ b/io_test.go
@@ -7,11 +7,19 @@ import (
 	"github.com/jordwest/mock-conn"
 )
 
+const (
+	welcomeExample = "{\"Type\":0,\"Root\":\"f4ae0b74-4025-4810-41d6-5148a513c580\",\"Recent\":[\"92d24e9d-12cc-4742-6aaf-ea781a6b09ec\",\"880be029-0d7c-4a3f-558d-d90bf79cbc1d\"],\"Major\":0,\"Minor\":1}"
+	newExample     = "{\"Type\":2,\"UUID\":\"92d24e9d-12cc-4742-6aaf-ea781a6b09ec\",\"Parent\":\"f4ae0b74-4025-4810-41d6-5148a513c580\",\"Content\":\"A riveting example message.\",\"Username\":\"Examplius_Caesar\",\"Timestamp\":1537738224}"
+	queryExample   = "{\"Type\":1,\"UUID\":\"f4ae0b74-4025-4810-41d6-5148a513c580\"}"
+)
+
 // TestMakeMessageReader checks that MakeMessageReader properly reads messages
-// from the input io.Reader.
+// from the input connection.
 func TestMakeMessageReader(t *testing.T) {
 	testMsgs := []string{
-		"{}\n",
+		newExample + "\n",
+		welcomeExample + "\n",
+		queryExample + "\n",
 	}
 	conn := mock_conn.NewConn()
 	recvChan := arbor.MakeMessageReader(conn.Client)
@@ -25,6 +33,36 @@ func TestMakeMessageReader(t *testing.T) {
 		parsed := <-recvChan
 		if parsed == nil {
 			t.Error("MakeMessageReader sent nil ProtocolMessage")
+		}
+	}
+}
+
+// TestMakeMessageReader checks that MakeMessageReader hangs up when it recieves bad
+// input.
+func TestMakeMessageReaderInvalid(t *testing.T) {
+	testMsgs := []string{
+		string([]byte{0x1b}) + "\n", // this is the ASCII escape character
+	}
+
+	for _, msg := range testMsgs {
+		conn := mock_conn.NewConn()
+		recvChan := arbor.MakeMessageReader(conn.Client)
+		server := conn.Server
+		testMsg := []byte(msg)
+		n, err := server.Write(testMsg)
+		if err != nil || n != len(testMsg) {
+			t.Skipf("Unable to write message \"%s\" into mock connection", msg)
+		}
+		parsed := <-recvChan
+		if parsed != nil {
+			t.Error("MakeMessageReader did not close output channel on bad input")
+		}
+		if n, err = server.Write(testMsg); err == nil {
+			// on a tcp connection, we'd get io.EOF, but our mock doesn't work that way.
+			// just need to make sure that we get an error
+			t.Error("MakeMessageReader failed to close the connection on bad input, no error on write")
+		} else if n > 0 {
+			t.Error("MakeMessageReader failed to close connection on bad input, able to write data")
 		}
 	}
 }

--- a/io_test.go
+++ b/io_test.go
@@ -37,7 +37,7 @@ func TestMakeMessageReader(t *testing.T) {
 	}
 }
 
-// TestMakeMessageReader checks that MakeMessageReader hangs up when it recieves bad
+// TestMakeMessageReaderInvalid checks that MakeMessageReader hangs up when it recieves bad
 // input.
 func TestMakeMessageReaderInvalid(t *testing.T) {
 	testMsgs := []string{

--- a/message_store_test.go
+++ b/message_store_test.go
@@ -18,7 +18,7 @@ func TestNewStore(t *testing.T) {
 
 func randomMessage() *arbor.ChatMessage {
 	m, _ := arbor.NewChatMessage(strconv.Itoa(rand.Int()))
-	m.AssignID()
+	_ = m.AssignID()
 	m.Username = strconv.Itoa(rand.Int())
 	return m
 }


### PR DESCRIPTION
In order to mitigate the DOS possibilities of sending malformed JSON,
I've started building more robust tests for the JSON reading. It's
not really functional yet but this commit lays the groundwork.

This work is both to bring better test coverage to the library and also to mitigate arborchat/server#1.