### PR TITLE
Defend against certain invalid messages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,14 +14,38 @@
   revision = "179d4d0c4d8d407a32af483c2354df1d2c91e6c3"
 
 [[projects]]
+  name = "github.com/onsi/gomega"
+  packages = [".","format","internal/assertion","internal/asyncassertion","internal/oraclematcher","internal/testingtsupport","matchers","matchers/support/goraph/bipartitegraph","matchers/support/goraph/edge","matchers/support/goraph/node","matchers/support/goraph/util","types"]
+  revision = "65fb64232476ad9046e57c26cd0bff3d3a8dc6cd"
+  version = "v1.4.3"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/net"
+  packages = ["html","html/atom","html/charset"]
+  revision = "927f97764cc334a6575f4b7a1584a147864d5723"
+
+[[projects]]
+  name = "golang.org/x/text"
+  packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/utf8internal","language","runes","transform","unicode/cldr"]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d6c5f3694c4252da5b3451fa4f0292c2fa9a2a7c7d3c86283bb54fe87349eb56"
+  inputs-digest = "713b4a4efe16008286038b1137d2070e0a082f7028ba9125e8800e26ad44a686"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/io.go
+++ b/io.go
@@ -85,7 +85,14 @@ func (r *ProtocolReader) readLoop(conn io.Reader) {
 	defer close(r.out)
 	decoder := json.NewDecoder(conn)
 	for msg := range r.in {
-		r.out <- decoder.Decode(msg)
+		err := decoder.Decode(msg)
+		if err != nil {
+			r.out <- err
+		} else if !msg.IsValid() {
+			r.out <- fmt.Errorf("Read invalid message %v", msg)
+		} else {
+			r.out <- nil
+		}
 	}
 }
 

--- a/io_test.go
+++ b/io_test.go
@@ -8,6 +8,7 @@ import (
 
 	arbor "github.com/arborchat/arbor-go"
 	"github.com/jordwest/mock-conn"
+	"github.com/onsi/gomega"
 )
 
 const (
@@ -92,6 +93,26 @@ func TestReaderRead(t *testing.T) {
 	}
 	if !proto.Equals(welcome) {
 		t.Errorf("Expected %v, got %v", welcome, proto)
+	}
+}
+
+// TestReaderInvalid ensures that we reject incomplete messages when we read them.
+func TestReaderInvalid(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	buf := new(bytes.Buffer)
+	for _, bad := range []string{"{\"Type\":1}", "{\"Type\":2}"} {
+		if _, err := buf.Write([]byte(bad)); err != nil {
+			t.Skip(err)
+		}
+		reader, err := arbor.NewProtocolReader(buf)
+		if err != nil {
+			t.Skip("Unable to construct Reader with valid input", err)
+		} else if reader == nil {
+			t.Skip("Got nil Reader back when invoking constructor with valid input")
+		}
+		proto := arbor.ProtocolMessage{}
+		err = reader.Read(&proto)
+		g.Expect(err).ToNot(gomega.BeNil())
 	}
 }
 

--- a/protocol_message.go
+++ b/protocol_message.go
@@ -103,3 +103,65 @@ func (m *ProtocolMessage) String() string {
 	dataString := string(data)
 	return dataString
 }
+
+// IsValid returns whether the message has the minimum correct fields for its message
+// type.
+func (m *ProtocolMessage) IsValid() bool {
+	switch m.Type {
+	case WelcomeType:
+		return m.IsValidWelcome()
+	case QueryType:
+		return m.IsValidQuery()
+	case NewMessageType:
+		return m.IsValidNew()
+	default:
+		return false
+	}
+}
+
+// IsValidWelcome checks that the message is a valid Welcome message.
+func (m *ProtocolMessage) IsValidWelcome() bool {
+	switch {
+	case m.Type != WelcomeType:
+		fallthrough
+	case m.Major == 0 && m.Minor == 0:
+		fallthrough
+	case m.Recent == nil:
+		fallthrough
+	case m.Root == "":
+		return false
+	}
+	return true
+}
+
+// IsValidNew checks that the message is a valid New message.
+func (m *ProtocolMessage) IsValidNew() bool {
+	switch {
+	case m.Type != NewMessageType:
+		fallthrough
+	case m.ChatMessage == nil:
+		fallthrough
+	case m.Username == "":
+		fallthrough
+	case m.Parent == "":
+		fallthrough
+	case m.Content == "":
+		fallthrough
+	case m.Timestamp == 0:
+		return false
+	}
+	return true
+}
+
+// IsValidQuery checks that the message is a valid Query message.
+func (m *ProtocolMessage) IsValidQuery() bool {
+	switch {
+	case m.Type != QueryType:
+		fallthrough
+	case m.ChatMessage == nil:
+		fallthrough
+	case m.UUID == "":
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
@Caton101 Discovered that messages of the form `{"Type":1}` can crash the server. This was because the JSON decoder didn't populate the nested `*arbor.ChatMessage` pointer if none of its fields were present in the JSON. Now, the Reader will validate that each message that it reads and generate an error if any required fields are missing. This should immunize both clients and servers against this kind of message.