### PR TITLE
Sample implementation of protocol 0.2

### DIFF
--- a/chat_message.go
+++ b/chat_message.go
@@ -7,6 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Post is a single chat message within Arbor
+type Post ChatMessage
+
 // ChatMessage represents a single chat message sent between users.
 type ChatMessage struct {
 	UUID      string

--- a/protocol_message.go
+++ b/protocol_message.go
@@ -204,6 +204,7 @@ func (m *ProtocolMessage) IsValidQuery() bool {
 	return true
 }
 
+// IsValidMeta returns whether the message is valid as a META-type protocol message.
 func (m *ProtocolMessage) IsValidMeta() bool {
 	switch {
 	case m.Type != MetaType:

--- a/protocol_message.go
+++ b/protocol_message.go
@@ -12,7 +12,14 @@ const (
 	QueryType = 1
 	// NewMessageType should be used as the `Type` field of a NEW_MESSAGE ProtocolMessage
 	NewMessageType = 2
+	// NewType is the `Type` of a NEW Message
+	NewType = 2
+	// MetaType is the `Type` of a META Message
+	MetaType = 3
 )
+
+// Message is a protocol-layer message in Arbor
+type Message ProtocolMessage
 
 // ProtocolMessage represents a message in the Arbor chat protocol. This may or
 // may not contain a chat message sent between users.
@@ -31,6 +38,8 @@ type ProtocolMessage struct {
 	// Message is the actual chat message content, if any. This is currently only
 	// used in NEW_MESSAGE messages
 	*ChatMessage
+	// Meta is the `Meta` field in META type arbor messages.
+	Meta map[string]string
 }
 
 // Equals returns true if other is equivalent to the message (has the same data or is the same message)
@@ -52,6 +61,9 @@ func (m *ProtocolMessage) Equals(other *ProtocolMessage) bool {
 	if !sameSlice(m.Recent, other.Recent) {
 		return false
 	}
+	if !sameMap(m.Meta, other.Meta) {
+		return false
+	}
 	return true
 }
 
@@ -65,6 +77,21 @@ func sameSlice(a, b []string) bool {
 	}
 	for i, v := range a {
 		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameMap(a, b map[string]string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for key, val := range a {
+		if val != b[key] {
 			return false
 		}
 	}
@@ -92,6 +119,11 @@ func (m *ProtocolMessage) MarshalJSON() ([]byte, error) {
 			*ChatMessage
 			Type uint8
 		}{ChatMessage: m.ChatMessage, Type: m.Type})
+	case MetaType:
+		return json.Marshal(struct {
+			Meta map[string]string
+			Type uint8
+		}{Type: m.Type, Meta: m.Meta})
 	default:
 		return nil, fmt.Errorf("Unknown message type, could not marshal")
 	}
@@ -114,6 +146,8 @@ func (m *ProtocolMessage) IsValid() bool {
 		return m.IsValidQuery()
 	case NewMessageType:
 		return m.IsValidNew()
+	case MetaType:
+		return m.IsValidMeta()
 	default:
 		return false
 	}
@@ -127,6 +161,8 @@ func (m *ProtocolMessage) IsValidWelcome() bool {
 	case m.Major == 0 && m.Minor == 0:
 		fallthrough
 	case m.Recent == nil:
+		fallthrough
+	case m.Meta != nil && len(m.Meta) != 0:
 		fallthrough
 	case m.Root == "":
 		return false
@@ -145,6 +181,8 @@ func (m *ProtocolMessage) IsValidNew() bool {
 		fallthrough
 	case m.Content == "":
 		fallthrough
+	case m.Meta != nil && len(m.Meta) != 0:
+		fallthrough
 	case m.Timestamp == 0:
 		return false
 	}
@@ -158,7 +196,27 @@ func (m *ProtocolMessage) IsValidQuery() bool {
 		fallthrough
 	case m.ChatMessage == nil:
 		fallthrough
+	case m.Meta != nil && len(m.Meta) != 0:
+		fallthrough
 	case m.UUID == "":
+		return false
+	}
+	return true
+}
+
+func (m *ProtocolMessage) IsValidMeta() bool {
+	switch {
+	case m.Type != MetaType:
+		fallthrough
+	case m.Meta == nil:
+		fallthrough
+	case m.ChatMessage != nil:
+		fallthrough
+	case m.Major != 0 || m.Minor != 0:
+		fallthrough
+	case m.Root != "":
+		fallthrough
+	case m.Recent != nil:
 		return false
 	}
 	return true

--- a/protocol_message_test.go
+++ b/protocol_message_test.go
@@ -64,16 +64,21 @@ func contains(input string, noneOf []string, eachOf []string) bool {
 	return !containsAnyOf(input, noneOf) && !containsEachOf(input, eachOf)
 }
 
-// TestMarshalJSON ensures that the JSON serialization for each message type works
+var (
+	// define fields that are only legal in specific message types for use in
+	// serialization tests
+	welcomeOnlyFields = []string{"Root", "Recent", "Major", "Minor"}
+	welcomeAllFields  = append(welcomeOnlyFields, "Type")
+	newOnlyFields     = []string{"Content", "Parent", "Username", "Timestamp"}
+	newAllFields      = append(newOnlyFields, "Type", "UUID")
+	metaOnlyFields    = []string{"Meta"}
+	metaAllFields     = append(metaOnlyFields, "Type")
+	queryAllFields    = []string{"Type", "UUID"}
+)
+
+// TestMarshalJSONWelcome ensures that the JSON serialization for WELCOME messages works
 // and does not include message fields irrelevant for that message type.
-func TestMarshalJSON(t *testing.T) {
-	welcomeOnlyFields := []string{"Root", "Recent", "Major", "Minor"}
-	welcomeAllFields := append(welcomeOnlyFields, "Type")
-	newOnlyFields := []string{"Content", "Parent", "Username", "Timestamp"}
-	newAllFields := append(newOnlyFields, "Type", "UUID")
-	metaOnlyFields := []string{"Meta"}
-	metaAllFields := append(metaOnlyFields, "Type")
-	queryAllFields := []string{"Type", "UUID"}
+func TestMarshalJSONWelcome(t *testing.T) {
 	strWelcome := marshalOrFail(t, getWelcome())
 	if strWelcome == "" {
 		t.Error("Received empty string")
@@ -81,6 +86,11 @@ func TestMarshalJSON(t *testing.T) {
 	if contains(strWelcome, append(newOnlyFields, metaOnlyFields...), welcomeAllFields) {
 		t.Error("Welcome message contained invalid fields", strWelcome)
 	}
+}
+
+// TestMarshalJSONNew ensures that the JSON serialization for NEW messages works
+// and does not include message fields irrelevant for that message type.
+func TestMarshalJSONNew(t *testing.T) {
 	strNewmessage := marshalOrFail(t, getNew())
 	if strNewmessage == "" {
 		t.Error("Received empty string")
@@ -88,6 +98,11 @@ func TestMarshalJSON(t *testing.T) {
 	if contains(strNewmessage, append(welcomeOnlyFields, metaOnlyFields...), newAllFields) {
 		t.Error("New message contained invalid fields", strNewmessage)
 	}
+}
+
+// TestMarshalJSONQuery ensures that the JSON serialization for QUERY messages works
+// and does not include message fields irrelevant for that message type.
+func TestMarshalJSONQuery(t *testing.T) {
 	strQuery := marshalOrFail(t, getQuery())
 	if strQuery == "" {
 		t.Error("Received empty string")
@@ -95,6 +110,11 @@ func TestMarshalJSON(t *testing.T) {
 	if contains(strQuery, append(append(welcomeOnlyFields, newAllFields...), metaOnlyFields...), queryAllFields) {
 		t.Error("Query message contained invalid fields", strQuery)
 	}
+}
+
+// TestMarshalJSONMeta ensures that the JSON serialization for META messages works
+// and does not include message fields irrelevant for that message type.
+func TestMarshalJSONMeta(t *testing.T) {
 	strMeta := marshalOrFail(t, getMeta())
 	if strMeta == "" {
 		t.Error("Received empty string")
@@ -102,6 +122,10 @@ func TestMarshalJSON(t *testing.T) {
 	if contains(strMeta, append(welcomeOnlyFields, newAllFields...), metaAllFields) {
 		t.Error("Query message contained invalid fields", strMeta)
 	}
+}
+
+// TestMarshalJSONInvalid ensures that the JSON serialization for invalid messages fails
+func TestMarshalJSONInvalid(t *testing.T) {
 	badOutput, err := getInvalid().MarshalJSON()
 	if err == nil {
 		t.Error("Marshalling bad message type should be error")

--- a/protocol_message_test.go
+++ b/protocol_message_test.go
@@ -49,6 +49,13 @@ func getQuery() *arbor.ProtocolMessage {
 	}
 }
 
+func getMeta() *arbor.ProtocolMessage {
+	return &arbor.ProtocolMessage{
+		Type: arbor.MetaType,
+		Meta: map[string]string{"key": "value"},
+	}
+}
+
 func getInvalid() *arbor.ProtocolMessage {
 	return &arbor.ProtocolMessage{Type: testBadMessageType}
 }
@@ -64,27 +71,36 @@ func TestMarshalJSON(t *testing.T) {
 	welcomeAllFields := append(welcomeOnlyFields, "Type")
 	newOnlyFields := []string{"Content", "Parent", "Username", "Timestamp"}
 	newAllFields := append(newOnlyFields, "Type", "UUID")
+	metaOnlyFields := []string{"Meta"}
+	metaAllFields := append(metaOnlyFields, "Type")
 	queryAllFields := []string{"Type", "UUID"}
 	strWelcome := marshalOrFail(t, getWelcome())
 	if strWelcome == "" {
 		t.Error("Received empty string")
 	}
-	if contains(strWelcome, newOnlyFields, welcomeAllFields) {
+	if contains(strWelcome, append(newOnlyFields, metaOnlyFields...), welcomeAllFields) {
 		t.Error("Welcome message contained invalid fields", strWelcome)
 	}
 	strNewmessage := marshalOrFail(t, getNew())
 	if strNewmessage == "" {
 		t.Error("Received empty string")
 	}
-	if contains(strNewmessage, welcomeOnlyFields, newAllFields) {
+	if contains(strNewmessage, append(welcomeOnlyFields, metaOnlyFields...), newAllFields) {
 		t.Error("New message contained invalid fields", strNewmessage)
 	}
 	strQuery := marshalOrFail(t, getQuery())
 	if strQuery == "" {
 		t.Error("Received empty string")
 	}
-	if contains(strQuery, append(welcomeOnlyFields, newAllFields...), queryAllFields) {
+	if contains(strQuery, append(append(welcomeOnlyFields, newAllFields...), metaOnlyFields...), queryAllFields) {
 		t.Error("Query message contained invalid fields", strQuery)
+	}
+	strMeta := marshalOrFail(t, getMeta())
+	if strMeta == "" {
+		t.Error("Received empty string")
+	}
+	if contains(strMeta, append(welcomeOnlyFields, newAllFields...), metaAllFields) {
+		t.Error("Query message contained invalid fields", strMeta)
 	}
 	badOutput, err := getInvalid().MarshalJSON()
 	if err == nil {


### PR DESCRIPTION
This adds the META message type to the library and introduces some type aliases for items that are being renamed in the new protocol. The spec that this implements is proposed [here](https://github.com/arborchat/protocol/pull/6). An example of integrating this protocol version with the server will follow shortly.