### PR TITLE
Ensure root messages pass validation

### DIFF
--- a/protocol_message.go
+++ b/protocol_message.go
@@ -143,8 +143,6 @@ func (m *ProtocolMessage) IsValidNew() bool {
 		fallthrough
 	case m.Username == "":
 		fallthrough
-	case m.Parent == "":
-		fallthrough
 	case m.Content == "":
 		fallthrough
 	case m.Timestamp == 0:


### PR DESCRIPTION
I didn't notice that this validation failed when you were dealing with the root message (since it has no parent). This is trickling up to `muscadine` by making us hang up on the server when we receive a copy of the root message (since the server sent us an "invalid" message).